### PR TITLE
Add plugin to allow users to initiate deletion of rtmbot messages

### DIFF
--- a/docs/example-plugins/bot-management.conf
+++ b/docs/example-plugins/bot-management.conf
@@ -1,0 +1,3 @@
+BOT_MESSAGE_DELETE_REACTIONS: ['wastebasket', 'toilet', 'hole', 'fire', 'bomb', 'trogdor']
+
+BOT_MESSAGE_DELETE_AUTH_USERS: ['admin', 'moderator']

--- a/docs/example-plugins/bot-management.py
+++ b/docs/example-plugins/bot-management.py
@@ -1,0 +1,25 @@
+from __future__ import unicode_literals
+# don't convert to ascii in py2.7 when creating string to return
+import yaml
+from client import slack_client as sc
+
+# Import variables from config file
+config = yaml.load(open('plugins/bot-management.conf', 'r'))
+
+bot_message_delete_reactions = config.get('BOT_MESSAGE_DELETE_REACTIONS')
+# user permission requirement not yet implemented
+bot_message_delete_auth_users = config.get('BOT_MESSAGE_DELETE_AUTH_USERS')
+
+def bot_message_delete(data):
+    if data['reaction'] in bot_message_delete_reactions:# and data['user'] in bot_message_delete_auth_users:
+        response = sc.api_call(
+            'chat.delete',
+            ts=data['item']['ts'],
+            channel=data['item']['channel']
+            )
+
+def process_reaction_added(data):
+    try:
+        bot_message_delete(data)
+    except:
+        pass


### PR DESCRIPTION
Added a plugin and configuration file that allows users to initiate the deletion of a message made by rtmbot by applying one of a specific set of reactions.